### PR TITLE
Parsing of keyspace dbs infos, final metric name definition support and metric names from config file

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,10 @@
         "metric": {
             "format": "{REDIS_ADDRESS}.{METRIC}"
         },
+        "redis": {
+            "metrics_delta": ["expired_keys", "evicted_keys", "keyspace_hits", "keyspace_misses", "total_connections_received", "total_commands_processed"],
+            "metrics_static": ["instantaneous_ops_per_sec", "used_memory", "mem_fragmentation_ratio", "connected_clients", "rejected_connections"]
+        },
         "logs": {
             "level": "debug",
             "path": "./logs"
@@ -17,6 +21,10 @@
     "production" : {
         "metric": {
             "format": "{REDIS_ADDRESS}.{METRIC}"
+        },
+        "redis": {
+            "metrics_delta": ["expired_keys", "evicted_keys", "keyspace_hits", "keyspace_misses", "total_connections_received", "total_commands_processed"],
+            "metrics_static": ["instantaneous_ops_per_sec", "used_memory", "mem_fragmentation_ratio", "connected_clients", "rejected_connections"]
         },
         "logs": {
             "level": "warn",

--- a/config.json
+++ b/config.json
@@ -1,5 +1,8 @@
 {
     "development" : {
+        "metric": {
+            "format": "{REDIS_ADDRESS}.{METRIC}"
+        },
         "logs": {
             "level": "debug",
             "path": "./logs"
@@ -12,6 +15,9 @@
     },
 
     "production" : {
+        "metric": {
+            "format": "{REDIS_ADDRESS}.{METRIC}"
+        },
         "logs": {
             "level": "warn",
             "path": "/var/log/redis2statsd"

--- a/lib/RedisInfoObserver.js
+++ b/lib/RedisInfoObserver.js
@@ -77,7 +77,17 @@ var RedisInfoObserver = function() {
         lines.forEach(function(line) {
             var keyValue = line.split(":");
             if (keyValue.length === 2) {
-                parsedObject[keyValue[0]] = parseFloat(keyValue[1]) || keyValue[1];
+                var dbInfos = keyValue[1].split(",");
+                if (dbInfos.length === 3) {
+                    dbInfos.forEach(function(dbInfo) {
+                        var dbKV = dbInfo.split("=");
+                        if (dbKV.length === 2) {
+                            parsedObject[keyValue[0]+"_"+dbKV[0]] = parseFloat(dbKV[1]) || dbKV[1];
+                        }
+                    });
+                } else {
+                    parsedObject[keyValue[0]] = parseFloat(keyValue[1]) || keyValue[1];
+                }
             }
         });
         return parsedObject;

--- a/lib/RedisMetricsController.js
+++ b/lib/RedisMetricsController.js
@@ -8,8 +8,8 @@ var RedisMetricsController = function() {
         lastInfo = {},
         started = false;
 
-    var DELTA_METRICS = ["expired_keys", "evicted_keys", "keyspace_hits", "keyspace_misses", "total_connections_received", "total_commands_processed"],
-        STATIC_METRICS = ["instantaneous_ops_per_sec", "used_memory", "mem_fragmentation_ratio", "connected_clients", "rejected_connections"];
+    var DELTA_METRICS= environment.redis.metrics_delta,
+        STATIC_METRICS = environment.redis.metrics_static;
 
     var RedisInfoObserver = bag.grab("RedisInfoObserver"),
         StasdInterface = bag.grab("StasdInterface");

--- a/lib/RedisMetricsController.js
+++ b/lib/RedisMetricsController.js
@@ -1,4 +1,5 @@
 var bilbo = require("bilbo"),
+    environment = require("./environment"),
     logger = require("./logger");
 
 var RedisMetricsController = function() {
@@ -31,7 +32,13 @@ var RedisMetricsController = function() {
 
     var addRedisAddressToMetricName = function(address, metric) {
         var normalizedAddress = address.replace(/\.|:/g, "-");
-        return normalizedAddress + "." + metric;
+        if (environment.metric && environment.metric.format) {
+            return environment.metric.format
+                .replace("{METRIC}", metric)
+                .replace("{REDIS_ADDRESS}", normalizedAddress);
+        } else {
+            return normalizedAddress + "." + metric;
+        }
     };
 
     var processAndSendData = function(data) {
@@ -42,7 +49,7 @@ var RedisMetricsController = function() {
         DELTA_METRICS.forEach(function(metric) {
             metricName = addRedisAddressToMetricName(data.address, metric);
             if (currentInfo.hasOwnProperty(metric) && deltaTime > 0) {
-                metricsData[metricName + "_per_sec"] = calcRate(currentInfo[metric], lastInfo[data.address][metric], deltaTime);
+                metricsData[metricName.replace(metric, metric + "_per_sec")] = calcRate(currentInfo[metric], lastInfo[data.address][metric], deltaTime);
             }
         });
 

--- a/lib/RedisMetricsController.js
+++ b/lib/RedisMetricsController.js
@@ -8,8 +8,8 @@ var RedisMetricsController = function() {
         lastInfo = {},
         started = false;
 
-    var DELTA_METRICS = ["expired_key", "evicted_keys", "keyspace_hits", "keyspace_misses", "total_connections_received", "total_commands_processed"],
-        STATIC_METRICS = ["instantaneous_ops_per_sec", "used_memory", "mem_fragmentation_ratio", "connected_clients", "instantaneous_ops_per_sec", "rejected_connections"];
+    var DELTA_METRICS = ["expired_keys", "evicted_keys", "keyspace_hits", "keyspace_misses", "total_connections_received", "total_commands_processed"],
+        STATIC_METRICS = ["instantaneous_ops_per_sec", "used_memory", "mem_fragmentation_ratio", "connected_clients", "rejected_connections"];
 
     var RedisInfoObserver = bag.grab("RedisInfoObserver"),
         StasdInterface = bag.grab("StasdInterface");

--- a/test/RedisMetricsControllerTest.js
+++ b/test/RedisMetricsControllerTest.js
@@ -32,12 +32,12 @@ describe('RedisMetricsController', function() {
     });
 
     describe("Metric calculation", function() {
-        it("should calc expired_key_per_sec", function(done) {
+        it("should calc expired_keys_per_sec", function(done) {
             var addresses = ["someaddress"],
                 interval = 60,
 
                 expectedData = {
-                    "someaddress.expired_key_per_sec": 10
+                    "someaddress.expired_keys_per_sec": 10
                 },
                 rmc,
                 first = true;
@@ -49,12 +49,12 @@ describe('RedisMetricsController', function() {
                         address: "someaddress",
                         info: {
                             "uptime_in_seconds": 0,
-                            "expired_key": 0
+                            "expired_keys": 0
                         }
                     };
                     if (!first) {
                         data.info.uptime_in_seconds = 60;
-                        data.info.expired_key = 600;
+                        data.info.expired_keys = 600;
                     }
                     onInfoCallback(null, data);
                     first = false;


### PR DESCRIPTION
This PR wll:
- [x] Parse keyspaces dbs like `db0:keys=668,expires=0,avg_ttl=0` into `db0_keys: 668`, `db0_expires: 0` and `db0_avg_ttl: 0`;
- [x] Support de definition of the final metric name via config file. This will allow to define where we want to include the redis address in the metric name;
- [x] Remove duplicated metric `instantaneous_ops_per_sec` and fix `expired_key[s]` typo;
- [x] Get the metric names to monitor from config file.
