### PR TITLE
emit slave metrics

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,8 @@
         },
         "redis": {
             "metrics_delta": ["expired_keys", "evicted_keys", "keyspace_hits", "keyspace_misses", "total_connections_received", "total_commands_processed"],
-            "metrics_static": ["instantaneous_ops_per_sec", "used_memory", "mem_fragmentation_ratio", "connected_clients", "rejected_connections"]
+            "metrics_static": ["instantaneous_ops_per_sec", "used_memory", "mem_fragmentation_ratio", "connected_clients", "rejected_connections"],
+            "slave_metrics": true
         },
         "logs": {
             "level": "debug",
@@ -24,7 +25,8 @@
         },
         "redis": {
             "metrics_delta": ["expired_keys", "evicted_keys", "keyspace_hits", "keyspace_misses", "total_connections_received", "total_commands_processed"],
-            "metrics_static": ["instantaneous_ops_per_sec", "used_memory", "mem_fragmentation_ratio", "connected_clients", "rejected_connections"]
+            "metrics_static": ["instantaneous_ops_per_sec", "used_memory", "mem_fragmentation_ratio", "connected_clients", "rejected_connections"],
+            "slave_metrics": true
         },
         "logs": {
             "level": "warn",

--- a/lib/RedisMetricsController.js
+++ b/lib/RedisMetricsController.js
@@ -1,6 +1,9 @@
 var bilbo = require("bilbo"),
     environment = require("./environment"),
-    logger = require("./logger");
+    logger = require("./logger"),
+    _ = require("underscore"),
+    querystring = require('querystring'),
+    bigInt = require("big-integer");
 
 var RedisMetricsController = function() {
 
@@ -9,7 +12,8 @@ var RedisMetricsController = function() {
         started = false;
 
     var DELTA_METRICS= environment.redis.metrics_delta,
-        STATIC_METRICS = environment.redis.metrics_static;
+        STATIC_METRICS = environment.redis.metrics_static,
+        SLAVE_METRICS = environment.redis.slave_metrics;
 
     var RedisInfoObserver = bag.grab("RedisInfoObserver"),
         StasdInterface = bag.grab("StasdInterface");
@@ -59,9 +63,42 @@ var RedisMetricsController = function() {
                 metricsData[metricName] = currentInfo[metric];
             }
         });
+
+        if (SLAVE_METRICS && currentInfo.connected_slaves) {
+            _.extend(metricsData, getSlaveMetrics(data));
+        }
+
         StasdInterface.send(metricsData);
         lastInfo[data.address] = data.info;
     };
+
+    var getSlaveMetrics = function(data) {
+        var slaveMetrics = {};
+        var currentInfo = data.info;
+        var redisInstance = data.address;
+        try {
+            var masterOffset = bigInt(currentInfo.master_repl_offset || 0);
+            for (var i = 0; i < currentInfo.connected_slaves; i++) {
+                var slaveName = "slave" + i.toString();
+                var slaveString = currentInfo[slaveName];
+                if (slaveString) {
+                    slaveString = slaveString.split(',').join('&');
+                    var slaveObject = querystring.parse(slaveString);
+                    if (slaveObject) {
+                        var slaveOffset = bigInt(slaveObject["offset"] || 0);
+                        var slaveLagInBytes = masterOffset.subtract(slaveOffset);
+
+                        slaveMetrics[addRedisAddressToMetricName(redisInstance, slaveName + "_online")] = (slaveObject["state"] === 'online' ? 1 : 0);
+                        slaveMetrics[addRedisAddressToMetricName(redisInstance, slaveName + "_lag")] = parseInt(slaveObject["lag"]) || 0;
+                        slaveMetrics[addRedisAddressToMetricName(redisInstance, slaveName + "_lagBytes")] = slaveLagInBytes.toJSNumber();
+                    }
+                }
+            }
+        } catch (e) {
+        }
+
+        return slaveMetrics;
+    }
 
     var infoHandler = function(err, data) {
         if (!lastInfo.hasOwnProperty(data.address)) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "underscore": "~1.6.0",
     "nconf": "~0.6.9",
     "bilbo": "0.0.6",
-    "timekeeper": "0.0.4"
+    "timekeeper": "0.0.4",
+    "big-integer": "~1.6.0"
   },
   "devDependencies": {
     "grunt": "~0.4.2",


### PR DESCRIPTION
If config.json has slave_metrics set to true, then emit metrics for each connected slave:
- online
- lag 
- lagBytes


